### PR TITLE
Track line number, column number and add RFC 5234 specified parsers.

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -18,3 +18,4 @@ doc-comments = after-when-possible
 break-cases = all
 break-sequences = true
 break-before-in=fit-or-vertical
+indicate-nested-or-patterns = unsafe-no

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -305,3 +305,24 @@ let control =
         | '\x7F' ->
             true
         | _ -> false))
+
+let is_digit = function
+  | '0' .. '9' -> true
+  | _          -> false
+
+let digit = char_parser "DIGIT" (char_if is_digit)
+
+let dquote =
+  char_parser
+    "DQUOTE"
+    (char_if (function
+        | '"' -> true
+        | _   -> false))
+
+let hex_digit =
+  char_parser
+    "HEX DIGIT"
+    (char_if (function
+        | c when is_digit c -> true
+        | 'A' .. 'F' -> true
+        | _ -> false))

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -120,10 +120,10 @@ let char_if f state =
   match state.cc with
   | `Char c when f c ->
       let state, () = advance 1 state in
-      (state, Some c)
+      (state, c)
   | `Eof
-   |`Char _ ->
-      (state, None)
+  | `Char _ ->
+      parser_error state "%a doesn't match char_if." pp_current_char state.cc
 
 let satisfy f state =
   match state.cc with
@@ -131,7 +131,7 @@ let satisfy f state =
       let state, () = advance 1 state in
       (state, c)
   | `Char _
-   |`Eof ->
+  | `Eof ->
       parser_error
         state
         "%d: satisfy is 'false' for char '%a'"
@@ -251,3 +251,35 @@ let line state =
     | `Eof, _                -> (state, None)
   in
   loop (Buffer.create 1) state
+
+let alpha state =
+  try
+    char_if
+      (function
+        | 'a' .. 'z'
+        | 'A' .. 'Z' ->
+            true
+        | _ -> false)
+      state
+  with _ ->
+    parser_error
+      state
+      "current char '%a' is not an 'alpha' character."
+      pp_current_char
+      state.cc
+
+let bit state =
+  try
+    char_if
+      (function
+        | '0'
+        | '1' ->
+            true
+        | _ -> false)
+      state
+  with _ ->
+    parser_error
+      state
+      "current char '%a' is not an 'bit' character."
+      pp_current_char
+      state.cc

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -57,11 +57,10 @@ let ( <|> ) p q state = try p state with (_ : exn) -> q state
 let delay f state = f () state
 
 let advance n state =
-  let current_char offset = `Char state.src.[offset] in
   let len = String.length state.src in
   if state.offset + n < len then
     let offset = state.offset + n in
-    let state = {state with offset; cc = current_char offset} in
+    let state = {state with offset; cc = `Char state.src.[offset]} in
     (state, ())
   else
     let state = {state with offset = len; cc = `Eof} in

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -340,3 +340,8 @@ let lf =
     (char_if (function
         | '\n' -> true
         | _    -> false))
+
+let octect state =
+  match state.cc with
+  | `Char c -> (state, c)
+  | `Eof    -> parser_error state "EOF reached."

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -8,7 +8,6 @@
  *-------------------------------------------------------------------------*)
 type state =
   { src : string
-  ; len : int
   ; offset : int
   ; cc : current_char }
 
@@ -25,8 +24,7 @@ let pp_current_char fmt = function
   | `Eof    -> Format.fprintf fmt "EOF"
 
 let parse src p =
-  let len = String.length src in
-  let state = {src; len; offset = 0; cc = `Eof} in
+  let state = {src; offset = 0; cc = `Eof} in
   try
     let (_ : state), a = p state in
     Ok a
@@ -55,12 +53,13 @@ let delay f state = f () state
 
 let advance n state =
   let current_char offset = `Char state.src.[offset] in
-  if state.offset + n < state.len then
+  let len = String.length state.src in
+  if state.offset + n < len then
     let offset = state.offset + n in
     let state = {state with offset; cc = current_char offset} in
     (state, ())
   else
-    let state = {state with offset = state.len; cc = `Eof} in
+    let state = {state with offset = len; cc = `Eof} in
     (state, ())
 
 let end_of_input state =
@@ -72,7 +71,7 @@ let end_of_input state =
   (state, is_eof)
 
 let substring len state =
-  if state.offset + len < state.len then
+  if state.offset + len < String.length state.src then
     String.sub state.src state.offset len |> Option.some
   else None
 

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -283,3 +283,6 @@ let bit state =
       "current char '%a' is not an 'bit' character."
       pp_current_char
       state.cc
+
+let crlf state =
+  try string "\r\n" state with _ -> parser_error state "unable to parse CRLF"

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -345,3 +345,26 @@ let octect state =
   match state.cc with
   | `Char c -> (state, c)
   | `Eof    -> parser_error state "EOF reached."
+
+let space =
+  char_parser
+    "SPACE"
+    (char_if (function
+        | '\x20' -> true
+        | _      -> false))
+
+let vchar =
+  char_parser
+    "VCHAR"
+    (char_if (function
+        | '\x21' .. '\x7E' -> true
+        | _                -> false))
+
+let whitespace =
+  char_parser
+    "VCHAR"
+    (char_if (function
+        | '\x20'
+        | '\x09' ->
+            true
+        | _ -> false))

--- a/lib/reparse.ml
+++ b/lib/reparse.ml
@@ -326,3 +326,17 @@ let hex_digit =
         | c when is_digit c -> true
         | 'A' .. 'F' -> true
         | _ -> false))
+
+let htab =
+  char_parser
+    "HTAB"
+    (char_if (function
+        | '\t' -> true
+        | _    -> false))
+
+let lf =
+  char_parser
+    "LF"
+    (char_if (function
+        | '\n' -> true
+        | _    -> false))

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -130,3 +130,7 @@ val alpha : char t
 (** [alpha] returns a character which is in [A - Z] or [a .. z]. *)
 
 val bit : char t
+(** [bit] returns a character which is wither '0' or '1'. *)
+
+val crlf : unit t
+(** [crlf] parses CRLF. *)

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -15,29 +15,13 @@ type +'a t
 
 exception Parse_error of string
 
-val return : 'a -> 'a t
-(** [return v] creates a new parser that always returns constant [v]. *)
-
-val advance : int -> unit t
-(** [advance n] advances parser by the given [n] number of characters. *)
-
-val end_of_input : bool t
-(** [end_of_input] returns [true] if parser has reached end of input. *)
-
-(** {2 Executing} *)
-
 val parse : string -> 'a t -> ('a, exn) result
 (** [parse input p] executes parser [p] with [input]. *)
 
-(** {2 Combinators} *)
+val return : 'a -> 'a t
+(** [return v] creates a new parser that always returns constant [v]. *)
 
-val ( <|> ) : 'a t -> 'a t -> 'a t
-(** [p <|> q] creates a parser that executes [p] and returns the result if it is
-    successful. If false then it executes [q] and returns it. See [delay]. *)
-
-val delay : (unit -> 'a t) -> 'a t
-(** [delay f] delays the computation of [p] until it is required. [p] is
-    [p = f ()]. Use it together with [<|>]. *)
+(** {2 Operators} *)
 
 val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
 (** [p >>= q] executes [p] and if it succeeds executes [q] and returns it's
@@ -52,6 +36,20 @@ val ( *> ) : _ t -> 'a t -> 'a t
 
 val ( <* ) : 'a t -> _ t -> 'a t
 (** [p <* q] discards result from [q] and returns [p] *)
+
+val ( <|> ) : 'a t -> 'a t -> 'a t
+(** [p <|> q] creates a parser that executes [p] and returns the result if it is
+    successful. If false then it executes [q] and returns it. See [delay]. *)
+
+val delay : (unit -> 'a t) -> 'a t
+(** [delay f] delays the computation of [p] until it is required. [p] is
+    [p = f ()]. Use it together with [<|>]. *)
+
+val advance : int -> unit t
+(** [advance n] advances parser by the given [n] number of characters. *)
+
+val end_of_input : bool t
+(** [end_of_input] returns [true] if parser has reached end of input. *)
 
 (** {2 Basic Parsers} *)
 

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -51,6 +51,8 @@ val advance : int -> unit t
 val end_of_input : bool t
 (** [end_of_input] returns [true] if parser has reached end of input. *)
 
+val fail : string -> 'a t
+
 (** {2 Basic Parsers} *)
 
 val char : char -> char t

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -165,3 +165,12 @@ val lf : char t
 
 val octect : char t
 (** [octect] parse a byte of character, [%x00-FF] 8 bytes of data. *)
+
+val space : char t
+(** [space] parse a space character. *)
+
+val vchar : char t
+(** [vchar] parse a Visible (printing) character. *)
+
+val whitespace : char t
+(** [whitespace] parse a space or horizontal - ' ' or '\t' - character. *)

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -158,3 +158,10 @@ val htab : char t
 
 val lf : char t
 (** [lf] parse a linefeed ('\n') character. *)
+
+(* val lwsp : string t *)
+(** [lwsp] parse linear whitespaces - *(WSP / CRLF WSP). {b Note} Use of LWSP is
+    discouraged. See https://tools.ietf.org/html/rfc5234#appendix-B.1 *)
+
+val octect : char t
+(** [octect] parse a byte of character, [%x00-FF] 8 bytes of data. *)

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -65,15 +65,14 @@ val lnum : int t
 val cnum : int t
 (** [cnum] returns the current column number. *)
 
-(** {2 Basic Parsers} *)
+(** {2 Parsers} *)
 
 val char : char -> char t
 (** [char c] accepts character [c] from input exactly and returns it. Fails
     Otherwise.*)
 
-val char_if : (char -> bool) -> char option t
-(** [char_if f] accepts and returns [Some c] if [f c] is true. Otherwise it
-    returns [None]. *)
+val char_if : (char -> bool) -> char t
+(** [char_if f] accepts and returns [c] if [f c] is true. *)
 
 val satisfy : (char -> bool) -> char t
 (** [satisfy f] accepts a char [c] from input if [f c] is true and returns it.
@@ -124,3 +123,10 @@ val count_skip_many : 'a t -> int t
 val line : string option t
 (** [line] accepts and returns a line of input delimited by either [\n] or
     [\r\n]. Returns [None] if end of input is reached. *)
+
+(** {2 Core parsers - RFC 5254, Appending B.1. *)
+
+val alpha : char t
+(** [alpha] returns a character which is in [A - Z] or [a .. z]. *)
+
+val bit : char t

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -33,7 +33,11 @@ val parse : string -> 'a t -> ('a, exn) result
 
 val ( <|> ) : 'a t -> 'a t -> 'a t
 (** [p <|> q] creates a parser that executes [p] and returns the result if it is
-    successful. If false then it executes [q] and returns it. *)
+    successful. If false then it executes [q] and returns it. See [delay]. *)
+
+val delay : (unit -> 'a t) -> 'a t
+(** [delay f] delays the computation of [p] until it is required. [p] is
+    [p = f ()]. Use it together with [<|>]. *)
 
 val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
 (** [p >>= q] executes [p] and if it succeeds executes [q] and returns it's
@@ -49,10 +53,6 @@ val ( *> ) : _ t -> 'a t -> 'a t
 val ( <* ) : 'a t -> _ t -> 'a t
 (** [p <* q] discards result from [q] and returns [p] *)
 
-val delay : (unit -> 'a t) -> 'a t
-(** [delay f] delays the computation of [p] until it is required. [p] is
-    [p = f ()]. *)
-
 (** {2 Basic Parsers} *)
 
 val char : char -> char t
@@ -61,7 +61,7 @@ val char : char -> char t
 
 val char_if : (char -> bool) -> char option t
 (** [char_if f] accepts and returns [Some c] if [f c] is true. Otherwise it
-    returns [None]. Always succeeds. *)
+    returns [None]. *)
 
 val satisfy : (char -> bool) -> char t
 (** [satisfy f] accepts a char [c] from input if [f c] is true and returns it.

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -132,5 +132,14 @@ val alpha : char t
 val bit : char t
 (** [bit] returns a character which is wither '0' or '1'. *)
 
+val ascii_char : char t
+(** [ascii_char] parses any US-ASCII character. *)
+
+val cr : char t
+(** [cr] parser CR '\r' character. *)
+
 val crlf : unit t
-(** [crlf] parses CRLF. *)
+(** [crlf] parses CRLF - \r\n - string. *)
+
+val control : char t
+(** [control] parser characters in range %x00-1F or %x7F. *)

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -127,7 +127,7 @@ val line : string option t
 (** {2 Core parsers - RFC 5254, Appending B.1. *)
 
 val alpha : char t
-(** [alpha] returns a character which is in [A - Z] or [a .. z]. *)
+(** [alpha] parse a character which is in range [A - Z] or [a .. z]. *)
 
 val bit : char t
 (** [bit] returns a character which is wither '0' or '1'. *)
@@ -136,10 +136,19 @@ val ascii_char : char t
 (** [ascii_char] parses any US-ASCII character. *)
 
 val cr : char t
-(** [cr] parser CR '\r' character. *)
+(** [cr] parse CR '\r' character. *)
 
 val crlf : unit t
-(** [crlf] parses CRLF - \r\n - string. *)
+(** [crlf] parse CRLF - \r\n - string. *)
 
 val control : char t
-(** [control] parser characters in range %x00-1F or %x7F. *)
+(** [control] parse characters in range %x00-1F or %x7F. *)
+
+val digit : char t
+(** [digit] parse a digit character - [0 .. 9]. *)
+
+val dquote : char t
+(** [dquote] parse double quote character - '"'. *)
+
+val hex_digit : char t
+(** [hex_digit] parse a hexadecimal digit - [0..9, A, B, C, D, E, F]. *)

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -152,3 +152,9 @@ val dquote : char t
 
 val hex_digit : char t
 (** [hex_digit] parse a hexadecimal digit - [0..9, A, B, C, D, E, F]. *)
+
+val htab : char t
+(** [htab] parse a horizontal tab ('\t') character. *)
+
+val lf : char t
+(** [lf] parse a linefeed ('\n') character. *)

--- a/lib/reparse.mli
+++ b/lib/reparse.mli
@@ -13,10 +13,15 @@
 type +'a t
 (** Represents a parser type that returns value ['a]. *)
 
-exception Parse_error of string
+exception Parse_error of int * int * string
+(** [Parser_error (lnum, cnum, msg)] Raised by failed parsers. [lnum], [cnum] is
+    line number and column number respectively at the time of parser failure.
+    [msg] contains a descriptive error message. *)
 
-val parse : string -> 'a t -> ('a, exn) result
-(** [parse input p] executes parser [p] with [input]. *)
+val parse : ?count_lines:bool -> string -> 'a t -> ('a, exn) result
+(** [parse ~count_lines input p] executes parser [p] with [input]. If
+    [count_lines] is true then the parser counts line and column numbers. It is
+    [false] by default. *)
 
 val return : 'a -> 'a t
 (** [return v] creates a new parser that always returns constant [v]. *)
@@ -52,6 +57,13 @@ val end_of_input : bool t
 (** [end_of_input] returns [true] if parser has reached end of input. *)
 
 val fail : string -> 'a t
+(** [fail msg] fails the parser with [msg]. *)
+
+val lnum : int t
+(** [lnum] return the current line number. *)
+
+val cnum : int t
+(** [cnum] returns the current column number. *)
 
 (** {2 Basic Parsers} *)
 


### PR DESCRIPTION
Add parsers as specified in RFC 5234. See https://tools.ietf.org/html/rfc5234#appendix-B.1 